### PR TITLE
Strip zero width non-joiner character

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -693,6 +693,7 @@ onInputKeyDown = function(e) {
         temp.innerHTML = temp.innerHTML.replace(/<div>/gi, "\n")
         temp.innerHTML = temp.innerHTML.replace(/<\/div>/gi, "\n")
         temp.innerHTML = temp.innerHTML.replace(/&nbsp;/gi, ' ')
+        temp.innerHTML = temp.innerHTML.replace(/\u200C/gi, ' ')
 
         // Note: textContent is different from innerText
         // http://perfectionkills.com/the-poor-misunderstood-innerText/


### PR DESCRIPTION
Remove zero width non-joiner character to fix errors when copying and pasting lines of code in the repl