### PR TITLE
Made some CSS adjustments to the input field so that it can recognize a right-click in an empty prompt

### DIFF
--- a/replpad.css
+++ b/replpad.css
@@ -180,7 +180,9 @@ img.center { /* https://stackoverflow.com/a/7055404 */
      * as a note to try and find a better answer.
      */
     min-width: 30px;
-    display: inline;
+    min-height: 17px;
+    vertical-align: top;
+    display: inline-block;
 
     font-weight: normal;
     color: #000000;


### PR DESCRIPTION
I have made a few CSS adjustments to the input field to fix issue #37 ...

inline-block was needed for min-width and min-height to be enforced

min-height had to be set to the minimum height of a character
- this may need to be adjusted if you ever change the font being used

vertical-align had to be set to the top, otherwise the prompt would appear at the bottom of the min-height

It has been tested on the latest versions of Firefox and Chrome on Windows 10.