### PR TITLE
Added command history scrolling using the up and down arrows

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -53,6 +53,8 @@ var replpad
 //
 var input = null
 var input_resolve
+var input_history = []
+var input_history_index = -1
 var first_input = null
 var onInputKeyDown
 var placeCaretAtEnd
@@ -208,7 +210,7 @@ onInputKeyDown = function(e) {
         return
     }
 
-    if (e.key == 'Enter' || e.keycode == 13) { // !!! 13 is enter, standard??
+    if (e.key == 'Enter' || e.keyCode == 13) { // !!! 13 is enter, standard??
 
         // https://stackoverflow.com/a/6015906
         if (e.shiftKey && !input.classList.contains("multiline")) {
@@ -287,9 +289,33 @@ onInputKeyDown = function(e) {
 
         input_resolve(text)
         input_resolve = undefined
-
+        
+        input_history.push(text)
+        input_history_index = input_history.length
+        
         e.preventDefault()  // Allowing enter puts a <br>
         return
+    } else if (e.keyCode == 38) { // arrow - up
+        if (!input.classList.contains("multiline")) {
+            if (input_history_index > 0) {
+                input_history_index--
+                input.innerHTML = input_history[input_history_index]
+            }
+            
+            e.preventDefault()
+        }
+    } else if (e.keyCode == 40) { // arrow - down
+        if (!input.classList.contains("multiline")) {
+            if (input_history_index < input_history.length - 1) {
+                input_history_index++
+                input.innerHTML = input_history[input_history_index]
+            } else {
+                input_history_index = input_history.length
+                input.innerHTML = ''
+            }
+            
+            e.preventDefault()
+        }
     }
 
     // The trick for "magic undo" is to notice when Ctrl-Z is a no-op, and


### PR DESCRIPTION
Title says it all. It works like you would expect a Unix shell too. The up arrow takes you through past commands. The down arrow does the opposite. When you've reached the most recent command, the next down arrow will give you a blank prompt again. It does not take over the arrow keys during multi-line editing.

I also fixed a minor typo on the ENTER key check, i.e.
e.keyCode == 13 (the c used to be lowercase, which was an invalid check)