### PR TITLE
Tags are now restored properly when scrolling through your command history

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -323,7 +323,7 @@ onInputKeyDown = function(e) {
         if (!input.classList.contains("multiline")) {
             if (input_history_index > 0) {
                 input_history_index--
-                input.innerHTML = input_history[input_history_index]
+                input.textContent = input_history[input_history_index]
             }
 
             e.preventDefault()
@@ -332,10 +332,10 @@ onInputKeyDown = function(e) {
         if (!input.classList.contains("multiline")) {
             if (input_history_index < input_history.length - 1) {
                 input_history_index++
-                input.innerHTML = input_history[input_history_index]
+                input.textContent = input_history[input_history_index]
             } else {
                 input_history_index = input_history.length
-                input.innerHTML = ''
+                input.textContent = ''
             }
 
             e.preventDefault()


### PR DESCRIPTION
This fixes the issue identified in #56.

Using textContent will preserve the tags, whereas innerHTML was causing the browser to try to render them.