### PR TITLE
Allow printing HTML with multiple child nodes

### DIFF
--- a/replpad.reb
+++ b/replpad.reb
@@ -87,7 +87,7 @@ replpad-write: js-awaiter [
     let html = reb.Did(reb.ArgR('html'))
 
     if (html) {
-        replpad.appendChild(load(param))
+        replpad.insertAdjacentHTML('beforeend', param)
         return
     }
 


### PR DESCRIPTION
I ran into an annoying issue, while building the game tutorial, where I couldn't insert complex HTML when using `print/html` in the REPL.

e.g. `print/html "<div>1</div><div>2</div>"`

This would only output/insert the first `<div>1</div>`. This is a trivial example, but it was affecting things like trying to get multiple images to display on a single line.

The reason this is happening is because the `/html` refinement uses `load` to create an HTML element around the content. This function only uses the `firstChild` when inserting the content, and so this causes all other child elements to get removed.

Is there a reason it does this? If not, then I would suggest using the alternative method in my PR instead. It uses `insertAdjacentHTML` which allows you to insert arbitrary HTML and also preserve any events that are attached to it. It also bypasses load completely and will insert the HTML after the last child, similar to how `appendChild` works.

`<test-repl>` ran okay and the change doesn't appear to affect the UI in any way.