### PR TITLE
shared-array-buffer is not a separate flag

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
 
           <div class="line"><b>Note: "Modern" web browser is required!</b></div>
           <div class="line"><b>If using Firefox, you must <a href="shared-memory-firefox.png" target="_blank">enable shared_memory</a> in your `about:config`.</b></div>
-          <div class="line"><b>If using Chrome, you must <a href="webassembly-chrome-android.png" target="_blank">`#enable-webassembly-threads` and #`shared-array-buffer`</a> in your `chrome://flags`.</b></div>
+          <div class="line"><b>If using Chrome, you must <a href="webassembly-chrome-android.png" target="_blank">`#enable-webassembly-threads</a> in your `chrome://flags`.</b></div>
           <div class="line">If load fails, check dev console for errors (typically Ctrl-Shift-I).  Repository is at <a href="https://github.com/hostilefork/replpad-js">GitHub</a></div>
           <div><hr></div>
           <div class="line" id="console_out"><p>%index.html fetch complete...</p></div>


### PR DESCRIPTION
Enables support for the WebAssembly Threads proposal. Implies #shared-array-buffer and #enable-webassembly. – Mac, Windows, Linux, Chrome OS, Android