### PR TITLE
Replace READ/WRITE shims; Add HTTP(S), Clipboard, Log and Downloads schemes

### DIFF
--- a/replpad.reb
+++ b/replpad.reb
@@ -346,6 +346,58 @@ read-url-helper: js-awaiter [
 }
 
 
+; Implement rudimentary HTTP(S) schemes
+sys/make-scheme [
+    title: "In-Browser HTTP Scheme"
+    name: 'http
+
+    actor: [
+        ; could potentially fold in JS-HEAD around an INFO? wrapper
+
+        read: func [port] [
+            ; if port/spec/host = "gitlab.com" [
+            ;     CORSify-GitLab-Request port
+            ; ]
+
+            read-url-helper unspaced [form port/spec/scheme "://" port/spec/host port/spec/path]
+        ]
+
+        write: func [port data] [
+            fail [
+                {WRITE is not supported in the web console yet, due to the browser's}
+                {imposition of a security model (e.g. no local filesystem access).}
+                {Features may be added in a more limited sense, for doing HTTP POST}
+                {in form submissions.  Get involved if you know how!}
+            ]
+        ]
+    ]
+]
+
+sys/make-scheme [
+    title: "In-Browser HTTPS Scheme"
+    name: 'https
+
+    actor: [
+        read: func [port] [
+            ; if port/spec/host = "gitlab.com" [
+            ;     CORSify-GitLab-Request port
+            ; ]
+
+            read-url-helper unspaced [form port/spec/scheme "://" port/spec/host port/spec/path]
+        ]
+
+        write: func [port data] [
+            fail [
+                {WRITE is not supported in the web console yet, due to the browser's}
+                {imposition of a security model (e.g. no local filesystem access).}
+                {Features may be added in a more limited sense, for doing HTTP POST}
+                {in form submissions.  Get involved if you know how!}
+            ]
+        ]
+    ]
+]
+
+
 ; While raw.github.com links are offered via CORS, raw gitlab.com links
 ; (specified by a /raw/ in their URL) are not.  However, GitLab offers CORS via
 ; an API...so for our GitLab open source brothers & sisters we level the
@@ -457,58 +509,6 @@ adjust-url-for-do: func [
     ]
 
     return null
-]
-
-
-; Implement rudimentary HTTP(S) schemes
-sys/make-scheme [
-    title: "In-Browser HTTP Scheme"
-    name: 'http
-
-    actor: [
-        ; could potentially fold in JS-HEAD around an INFO? wrapper
-
-        read: func [port] [
-            ; if port/spec/host = "gitlab.com" [
-            ;     CORSify-GitLab-Request port
-            ; ]
-
-            read-url-helper unspaced [form port/spec/scheme "://" port/spec/host port/spec/path]
-        ]
-
-        write: func [port data] [
-            fail [
-                {WRITE is not supported in the web console yet, due to the browser's}
-                {imposition of a security model (e.g. no local filesystem access).}
-                {Features may be added in a more limited sense, for doing HTTP POST}
-                {in form submissions.  Get involved if you know how!}
-            ]
-        ]
-    ]
-]
-
-sys/make-scheme [
-    title: "In-Browser HTTPS Scheme"
-    name: 'https
-
-    actor: [
-        read: func [port] [
-            ; if port/spec/host = "gitlab.com" [
-            ;     CORSify-GitLab-Request port
-            ; ]
-
-            read-url-helper unspaced [form port/spec/scheme "://" port/spec/host port/spec/path]
-        ]
-
-        write: func [port data] [
-            fail [
-                {WRITE is not supported in the web console yet, due to the browser's}
-                {imposition of a security model (e.g. no local filesystem access).}
-                {Features may be added in a more limited sense, for doing HTTP POST}
-                {in form submissions.  Get involved if you know how!}
-            ]
-        ]
-    ]
 ]
 
 

--- a/replpad.reb
+++ b/replpad.reb
@@ -384,7 +384,7 @@ sys/make-scheme [
 
         read: func [port] [
             ; if port/spec/host = "gitlab.com" [
-            ;     CORSify-GitLab-Request port
+            ;     CORSify-if-gitlab-url port
             ; ]
 
             read-url-helper unspaced [form port/spec/scheme "://" port/spec/host port/spec/path]
@@ -408,7 +408,7 @@ sys/make-scheme [
     actor: [
         read: func [port] [
             ; if port/spec/host = "gitlab.com" [
-            ;     CORSify-GitLab-Request port
+            ;     CORSify-if-gitlab-url port
             ; ]
 
             read-url-helper unspaced [form port/spec/scheme "://" port/spec/host port/spec/path]
@@ -442,7 +442,8 @@ sys/make-scheme [
 ;
 ; TBD: research what that is and what the rule is on its appearance or not.
 ;
-CORSify-GitLab-Request: func [
+CORSify-if-gitlab-url: func [
+    return: [port!]
     port [port!]
     <local> user repo branch file_path
 ][
@@ -471,6 +472,8 @@ CORSify-GitLab-Request: func [
             "/repository/files/" file_path "/raw?ref=" branch
         ]
     ]
+
+    port
 ]
 
 

--- a/replpad.reb
+++ b/replpad.reb
@@ -60,6 +60,33 @@ Rebol [
 }
 
 
+use [write-console] [
+    write-console: js-awaiter [
+        return: [void!]
+        type [text!]
+        value [any-value!]
+    ] {
+        console[reb.Spell(reb.ArgR('type'))](reb.Spell(reb.ArgR('value')));
+    }
+
+    sys/make-scheme [
+        title: "Console.log Scheme"
+        name: 'log
+
+        init: func [port][
+            port/spec/path: form find/match port/spec/ref log:type=
+            assert [find ["info" "log" "warn" "error"] port/spec/path]
+        ]
+
+        actor: [
+            write: func [port data][
+                write-console port/spec/path form data
+            ]
+        ]
+    ]
+]
+
+
 cls: clear-screen: js-awaiter [
     {Clear contents of the browser window}
     return: [void!]
@@ -311,20 +338,21 @@ copy-to-clipboard-helper: js-native [
     }
 }
 
-write: func [
-    destination [any-value!]
-    data [any-value!]
-][
-    if destination = clipboard:// [
-        copy-to-clipboard-helper data
-        return
-    ]
 
-    fail 'source [
-        {WRITE is not supported in the web console yet, due to the browser's}
-        {imposition of a security model (e.g. no local filesystem access).}
-        {Features may be added in a more limited sense, for doing HTTP POST}
-        {in form submissions.  Get involved if you know how!}
+; Implement Clipboard scheme, no URL form dictated
+sys/make-scheme [
+    title: "In-Browser Clipboard Scheme"
+    name: 'clipboard
+
+    actor: [
+        read: func [port] [
+            fail {READ is not supported in the web console}
+        ]
+
+        write: func [port data] [
+            copy-to-clipboard-helper data
+            port
+        ]
     ]
 ]
 
@@ -967,7 +995,6 @@ sys/export [
     write-stdout
     print
     read-line
-    write
     browse
     download
     now

--- a/replpad.reb
+++ b/replpad.reb
@@ -912,6 +912,24 @@ download: js-native [  ; Method via https://jsfiddle.net/koldev/cW7W5/
 }
 
 
+sys/make-scheme [
+    title: "Downloader Scheme"
+    name: 'downloads
+
+    init: func [port][
+        assert [match text! port/spec/path]
+        port/spec/path: last split-path port/spec/path
+    ]
+
+    actor: [
+        write: func [port data][
+            download port/spec/path data
+            port
+        ]
+    ]
+]
+
+
 ; !!! The ABOUT command was not made part of the console extension, since
 ; non-console builds might want to be able to ask it from the command line.
 ; But it was put in HOST-START and not the mezzanine/help in general.  This


### PR DESCRIPTION
This replaces the shims for READ (tied to HTTP(S)) and WRITE (tied to Clipboard) with respective schemes. This restores READ and WRITE in order that further schemes can be implemented.

```
write clipboard:// to text! read https://raw.githubusercontent.com/hostilefork/replpad-js/master/replpad.reb
```

One such additional scheme is Log which permits WRITE to the browser console log:

```
write log:type=log "Message"
write log:type=warn "Warning"
write log:type=error "Error"
```

Another is a Downloads scheme:

```
write downloads:///file.txt "Some Text"
```