### PR TITLE
Add Local Storage-based storage schemes

### DIFF
--- a/replpad.reb
+++ b/replpad.reb
@@ -1340,6 +1340,8 @@ module [
                     ][
                         fail "No such file or directory"
                     ]
+
+                    port
                 ]
 
                 query: func [port] [
@@ -1400,7 +1402,7 @@ module [
                             keep storage-list port/spec/target form port/spec/ref
                         ]
                     ][
-                        fail "Directory does not exist"
+                        fail "No such file or directory"
                     ]
                 ]
 
@@ -1417,7 +1419,24 @@ module [
                 ]
 
                 delete: func [port] [
-                    fail "Directory delete not currently supported"
+                    case [
+                        did find [%/ %/tmp/] port/spec/ref [
+                            port
+                        ]
+
+                        not storage-exists? port/spec/target form port/spec/ref [
+                            fail "No such file or directory"
+                        ]
+
+                        not empty? read port/spec/ref [
+                            fail "Directory not empty"
+                        ]
+
+                        <else> [
+                            storage-unset port/spec/target form port/spec/ref
+                            port
+                        ]
+                    ]
                 ]
 
                 query: func [port] [


### PR DESCRIPTION
Included are patched CHANGE-DIR and CLEAN-PATH functions (may be worth reviewing and adding to the main build) and schemes including: basic access to `localStorage/sessionStorage` and file/directory schemes build on top of the same support functions.

The file/directory schemes are designed to mimic the behaviour of a desktop file system, but is somewhat simplistic in its approach. Data is encoded as Base64 so that binary values can be stored, however this reduces available space by a quarter.

As-is, this is more a proof-of-concept than a practical persistent storage scheme. That said, I don't believe it'd be too difficult for a motivated individual(s) to rework the scheme to use IndexedDB providing more reliability and space, remaining compatible with this and the desktop file/directory schemes.