### PR TITLE
Change inner input elements from DIV to SPAN

### DIFF
--- a/replpad.css
+++ b/replpad.css
@@ -116,6 +116,7 @@ img.center { /* https://stackoverflow.com/a/7055404 */
 
 #replpad {
     padding: 5px;  /* put a little space around the edge and from splitter */
+    padding-bottom: 3em;  /* leave some space at the bottom of the screen */
     flex-grow: 1;  /* allows the replpad to take up the remaining screen space */
 }
 
@@ -206,7 +207,7 @@ img.center { /* https://stackoverflow.com/a/7055404 */
     word-break: normal;
     white-space: pre;  /* inheriting pre-wrap won't show trailing space */
 
-    display: table-cell;
+    display: inline-block;
 }
 
 .input {
@@ -220,17 +221,10 @@ img.center { /* https://stackoverflow.com/a/7055404 */
     /* autocapitalize: "off"; */
     /* spellcheck: "false"; */
 
-    /* The width and height gives you a larger copy/paste area.
-     * The 100px for height also provides padding under the prompt so that
-     * you're not typing at the very bottom of the screen. It is possible to
-     * increase the height to get a larger copy/paste area, but this means
-     * the scrollbar will show up sooner too.
-     */
-    width: 100%;
-    height: 100px;
+    padding-right: 1px;  /* needs room to display cursor */
 
     vertical-align: top;
-    display: table-cell;
+    display: inline-block;
 
     font-weight: normal;
     color: #000000;

--- a/replpad.reb
+++ b/replpad.reb
@@ -350,11 +350,11 @@ read-line: js-awaiter [
     // The prompt is always a text node, and so we need to create a HTML
     // version of it to be able to adjust its layout next to the input.
     //
-    var prompt_html = document.createElement("div")
+    var prompt_html = document.createElement("span")
     prompt_html.innerHTML = prompt.textContent
     prompt_html.className = "input-prompt"
 
-    let new_input = load("<div class='input'></div>")
+    let new_input = load("<span class='input'></span>")
 
     // Add a container to place the prompt and input into.  This allows us to
     // adjust the width the input takes without making it drop to a new line.


### PR DESCRIPTION
This affects how text is copied and pasted from various browsers with 'block' display properties inserting newline characters and 'table-cell' display properties inserting tabs. This does mean that the input DIV now adapts to the size of its content as attempts to specify width and height have an adverse effect.

The net effect of these changes is that copying any portion of a ReplPad session should no longer have extaneous characters.